### PR TITLE
Removing unused [file] argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ngzip has started with the simplest solution using stdio.
 
 
 ```
-Usage: ngzip {OPTIONS} [file]
+Usage: ngzip {OPTIONS}
 
 Description:
 


### PR DESCRIPTION
It looks like specifying the output file in the arguments isn't supported at the moment, so I'm just pulling it from the readme.
