### PR TITLE
Allow input filename to be passed in as an arg

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,7 +2,6 @@
 
 var fs = require('fs');
 var minimist = require('minimist');
-var path = require('path');
 var zlib = require('zlib');
 
 var minimistOpts = {
@@ -22,6 +21,7 @@ var help = argv.help;
 var compressionLevel = (argv.fast) ? zlib.Z_BEST_SPEED :
     (argv.best) ? zlib.Z_BEST_COMPRESSION :
     zlib.Z_DEFAULT_COMPRESSION;
+var inputFilename = argv._[0]
 
 if (help) { // help
   return fs.createReadStream(__dirname + '/usage.txt')
@@ -55,7 +55,7 @@ function errorExit(err) {
     process.exit(1);
 }
 
-var inStream = process.stdin;
+var inStream = inputFilename ? fs.createReadStream(inputFilename) : process.stdin;
 var outStream = process.stdout;
 
 if (decompress) { // decompression


### PR DESCRIPTION
I found this library while looking for a cross-platform gzip tool, just like you your self wanted.

I really like my npm scripts to be cross-platform, so avoiding `cat`/`type` is a plus.  Specifying the input file accomplishes that for me, `>` works fine for the output.

I noticed that the [with-file](https://github.com/jeffbski/ngzip/tree/with-file) branch seems abandoned - I was wondering if you would accept this pull request with just the input filename as an option, since it adds so little complexity to the code.
